### PR TITLE
Fix missing brackets

### DIFF
--- a/doc_source/EventTypes.md
+++ b/doc_source/EventTypes.md
@@ -1616,6 +1616,7 @@ The AWS service affected by the event\. For example, `EC2`, `S3`, `REDSHIFT`, or
     "eventDescription": [{
       "language": "en_US",
       "latestDescription": "A description of the event will be provided here"
+    }]
   }
 }
 ```
@@ -1649,6 +1650,8 @@ The AWS service affected by the event\. For example, `EC2`, `S3`, `REDSHIFT`, or
       "tags": {
         "stage": "prod",
         "app": "my-app"
+      }
+    }]
   }
 }
 ```


### PR DESCRIPTION
*Description of changes:*
When I test with [test-event-pattern](https://docs.aws.amazon.com/cli/latest/reference/events/test-event-pattern.html), I notice the json objects are invalid with missing brackets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
